### PR TITLE
Added library.gift as one of the possible domains in the download links

### DIFF
--- a/libgen_api_modern/search_request.py
+++ b/libgen_api_modern/search_request.py
@@ -305,7 +305,7 @@ class SearchRequest:
                 download_links = record.find('ul', class_='record_mirrors').find_all('a')
                 mirror_link = None
                 for link in download_links:
-                    if 'library.lol/fiction' in link['href']:
+                    if 'library.lol/fiction' in link['href'] or 'library.gift/fiction' in link['href']:
                         mirror_link = link['href']
                         break
 


### PR DESCRIPTION
### Reason for the changes

Currently, no direct links are returned for the fiction category. 

### Description of changes

Added the domain `library.gift` as one of the possible options when trying to fetch the mirrors. 

### New behavior

Direct download links for the fiction category are now showing up correctly.